### PR TITLE
fix(terminal): auto-copy on selection and reliable Cmd+C

### DIFF
--- a/components/Terminal/hooks/terminal-init.ts
+++ b/components/Terminal/hooks/terminal-init.ts
@@ -75,23 +75,37 @@ export function createTerminal(
     document.body.removeChild(textarea);
   };
 
+  // True when focus is on an editable field outside the terminal
+  // (e.g. the search bar) — we must not hijack their copy/select.
+  const isExternalFormFieldFocused = () => {
+    const active = document.activeElement as HTMLElement | null;
+    if (!active || container.contains(active)) return false;
+    return (
+      active.tagName === "INPUT" ||
+      active.tagName === "TEXTAREA" ||
+      active.isContentEditable
+    );
+  };
+
   // Handle Cmd+A and Cmd+C via document event listener (more reliable than attachCustomKeyEventHandler)
   const handleKeyDown = (event: KeyboardEvent) => {
-    // Only handle when terminal is focused (xterm creates its textarea inside the container)
-    if (!container.contains(document.activeElement)) return;
-
     const key = event.key.toLowerCase();
 
-    // Cmd+A (macOS) / Ctrl+A for select all
+    // Cmd+A (macOS) / Ctrl+A for select all — only when terminal is focused
     if ((event.metaKey || event.ctrlKey) && key === "a") {
+      if (!container.contains(document.activeElement)) return;
       event.preventDefault();
       event.stopPropagation();
       term.selectAll();
       return;
     }
 
-    // Cmd+C (macOS) / Ctrl+C for copy when text is selected
+    // Cmd+C (macOS) / Ctrl+C: copy whenever the terminal has a selection.
+    // We can't rely on focus being inside the container — a mouse drag
+    // often leaves focus on <body>.
     if ((event.metaKey || event.ctrlKey) && key === "c") {
+      if (isExternalFormFieldFocused()) return;
+      if (!term.hasSelection()) return;
       const selection = term.getSelection();
       if (selection) {
         event.preventDefault();
@@ -101,11 +115,20 @@ export function createTerminal(
     }
   };
 
+  // Auto-copy after a mouse-drag selection (iTerm/tmux-style).
+  const handleMouseUp = () => {
+    if (!term.hasSelection()) return;
+    const selection = term.getSelection();
+    if (selection) copyToClipboard(selection);
+  };
+
   // Use capture phase to intercept before browser default
   document.addEventListener("keydown", handleKeyDown, true);
+  container.addEventListener("mouseup", handleMouseUp);
 
   const cleanup = () => {
     document.removeEventListener("keydown", handleKeyDown, true);
+    container.removeEventListener("mouseup", handleMouseUp);
   };
 
   return { term, fitAddon, searchAddon, cleanup };


### PR DESCRIPTION
## Problem

Two related bugs prevented users from copying text out of the terminal:

### 1. Mouse drag selection — nothing gets copied

After dragging to select text, xterm.js often drops focus to `<body>`. The existing `Cmd+C` handler was gated on `container.contains(document.activeElement)`, which silently returned early, leaving the selection on screen but nothing in the clipboard.

### 2. No auto-copy on selection

Unlike iTerm2, tmux copy-mode, or native terminal emulators, releasing a drag selection did not automatically write the text to the clipboard. Users had no way to copy unless `Cmd+C` worked (which it didn't after a drag).

## Solution

**`components/Terminal/hooks/terminal-init.ts`**

### Auto-copy on mouseup (primary fix)

Added a `mouseup` listener on the terminal container. When the user finishes a drag selection, the handler checks `term.hasSelection()` and immediately writes the selection to the clipboard via the existing `copyToClipboard` helper (with `execCommand` fallback for non-secure contexts). No keystroke required — identical to iTerm2's "Copy on Select" behaviour.

```
container.addEventListener("mouseup", handleMouseUp);
```

### Relaxed Cmd+C gate (secondary fix)

Replaced the strict `container.contains(document.activeElement)` check with a smarter guard:

- **Old**: only intercept Cmd+C when focus is inside the terminal container.
- **New**: intercept Cmd+C whenever the terminal has a selection, **unless** an editable field *outside* the terminal (INPUT / TEXTAREA / contentEditable) currently has focus.

This means:
- ✅ Cmd+C works after a mouse drag (focus is on `<body>`)
- ✅ Cmd+C works after `Cmd+A` select-all
- ✅ Cmd+C in the search bar still copies search-bar text (not terminal text)
- ✅ Cmd+C in any other input on the page is unaffected

### Cmd+A unchanged

`Cmd+A` (select all) still requires the terminal container to be focused — correct behaviour, since `Cmd+A` in the search bar should select its own text.

### Cleanup

Both the `keydown` and new `mouseup` listeners are removed in the `cleanup()` function returned by `createTerminal`. This prevents listener leaks when the terminal re-mounts (e.g. on theme change).

## Test plan

- [ ] Drag-select text in the terminal → release mouse → paste in another app: copied text appears
- [ ] `Cmd+A` in the terminal → `Cmd+C` → paste: full terminal buffer is copied
- [ ] Click into the search bar, select text, `Cmd+C`: search-bar text is copied (not terminal text)
- [ ] Drag-select in terminal, then click into search bar and type: no unexpected behaviour
- [ ] Open terminal, change theme (triggers re-mount), repeat copy test: no duplicate listeners / double-copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)