### PR TITLE
fix(agent-os): support provider-specific model selection

### DIFF
--- a/app/api/orchestrate/spawn/route.ts
+++ b/app/api/orchestrate/spawn/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { resolveModelForAgent } from "@/lib/model-catalog";
+import { isValidAgentType, type AgentType } from "@/lib/providers";
 import { spawnWorker } from "@/lib/orchestration";
 
 export async function POST(request: Request) {
@@ -10,9 +12,16 @@ export async function POST(request: Request) {
       workingDirectory,
       branchName,
       useWorktree = true,
-      model = "sonnet",
-      agentType = "claude",
+      model,
+      agentType: rawAgentType = "claude",
     } = body;
+    const agentType: AgentType = isValidAgentType(rawAgentType)
+      ? rawAgentType
+      : "claude";
+    const resolvedModel = resolveModelForAgent(
+      agentType,
+      typeof model === "string" ? model.trim() : model
+    );
 
     if (!conductorSessionId || !task || !workingDirectory) {
       return NextResponse.json(
@@ -30,7 +39,7 @@ export async function POST(request: Request) {
       workingDirectory,
       branchName,
       useWorktree,
-      model,
+      model: resolvedModel,
       agentType,
     });
 

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
 import { getDb, queries, type Session, type Group } from "@/lib/db";
 import { isValidAgentType, type AgentType } from "@/lib/providers";
+import { resolveModelForAgent } from "@/lib/model-catalog";
 import { createWorktree } from "@/lib/worktrees";
 import { setupWorktree, type SetupResult } from "@/lib/env-setup";
 import { findAvailablePort } from "@/lib/ports";
@@ -56,7 +57,7 @@ export async function POST(request: NextRequest) {
       name: providedName,
       workingDirectory = "~",
       parentSessionId = null,
-      model = "sonnet",
+      model: requestedModel = null,
       systemPrompt = null,
       groupPath = "sessions",
       claudeSessionId = null,
@@ -77,6 +78,12 @@ export async function POST(request: NextRequest) {
     const agentType: AgentType = isValidAgentType(rawAgentType)
       ? rawAgentType
       : "claude";
+    const project = projectId ? getProject(projectId) : null;
+    const model = resolveModelForAgent(
+      agentType,
+      (typeof requestedModel === "string" && requestedModel.trim()) ||
+        project?.default_model
+    );
 
     // Auto-generate name if not provided
     const name =
@@ -183,7 +190,6 @@ export async function POST(request: NextRequest) {
     const session = queries.getSession(db).get(id) as Session;
 
     // Get project's initial prompt if available
-    const project = projectId ? getProject(projectId) : null;
     const projectInitialPrompt = project?.initial_prompt?.trim();
     const sessionInitialPrompt = initialPrompt?.trim();
 

--- a/components/NewSessionDialog/hooks/useNewSessionForm.ts
+++ b/components/NewSessionDialog/hooks/useNewSessionForm.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { getProviderDefinition, type AgentType } from "@/lib/providers";
+import { resolveModelForAgent } from "@/lib/model-catalog";
 import type { ProjectWithDevServers } from "@/lib/projects";
 import { setPendingPrompt } from "@/stores/initialPrompt";
 import { useCreateSession } from "@/data/sessions";
@@ -243,11 +244,17 @@ export function useNewSessionForm({
       }, 2000);
     }
 
+    const projectDefaultModel = projects.find(
+      (project) => project.id === projectId
+    )?.default_model;
+    const resolvedModel = resolveModelForAgent(agentType, projectDefaultModel);
+
     createSession.mutate(
       {
         name: name.trim() || undefined,
         workingDirectory,
         projectId,
+        model: resolvedModel,
         agentType,
         useWorktree,
         featureName: useWorktree ? featureName.trim() : null,

--- a/components/Projects/NewProjectDialog.tsx
+++ b/components/Projects/NewProjectDialog.tsx
@@ -18,11 +18,8 @@ import {
 } from "@/components/ui/select";
 import { Link, GitBranch, FolderPlus, Check } from "lucide-react";
 import type { AgentType } from "@/lib/providers";
-import {
-  AGENT_OPTIONS,
-  MODEL_OPTIONS,
-  CLONE_STEP,
-} from "./NewProjectDialog.types";
+import { getModelOptions } from "@/lib/model-catalog";
+import { AGENT_OPTIONS, CLONE_STEP } from "./NewProjectDialog.types";
 import type { NewProjectDialogProps } from "./NewProjectDialog.types";
 import { useNewProjectForm } from "./hooks/useNewProjectForm";
 import { DevServersSection } from "./DevServersSection";
@@ -45,6 +42,10 @@ export function NewProjectDialog({
   onCreated,
 }: NewProjectDialogProps) {
   const form = useNewProjectForm(mode, onClose, onCreated);
+  const modelOptions = getModelOptions(form.agentType);
+  const selectedModelLabel =
+    modelOptions.find((option) => option.value === form.defaultModel)?.label ||
+    "Select a model";
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && form.handleClose()}>
@@ -117,7 +118,7 @@ export function NewProjectDialog({
             <label className="text-sm font-medium">Default Agent</label>
             <Select
               value={form.agentType}
-              onValueChange={(v) => form.setAgentType(v as AgentType)}
+              onValueChange={(v) => form.handleAgentTypeChange(v as AgentType)}
             >
               <SelectTrigger>
                 <SelectValue />
@@ -136,14 +137,15 @@ export function NewProjectDialog({
           <div className="space-y-2">
             <label className="text-sm font-medium">Default Model</label>
             <Select
+              key={form.agentType}
               value={form.defaultModel}
               onValueChange={form.setDefaultModel}
             >
               <SelectTrigger>
-                <SelectValue />
+                <SelectValue>{selectedModelLabel}</SelectValue>
               </SelectTrigger>
               <SelectContent>
-                {MODEL_OPTIONS.map((opt) => (
+                {modelOptions.map((opt) => (
                   <SelectItem key={opt.value} value={opt.value}>
                     {opt.label}
                   </SelectItem>

--- a/components/Projects/NewProjectDialog.types.ts
+++ b/components/Projects/NewProjectDialog.types.ts
@@ -40,12 +40,6 @@ export const AGENT_OPTIONS: { value: AgentType; label: string }[] = [
   { value: "omp", label: "Oh My Pi" },
 ];
 
-export const MODEL_OPTIONS = [
-  { value: "sonnet", label: "Sonnet" },
-  { value: "opus", label: "Opus" },
-  { value: "haiku", label: "Haiku" },
-];
-
 export function extractRepoName(url: string): string | null {
   const match = url.match(
     /(?:github\.com[/:][\w.-]+\/([\w.-]+?)(?:\.git)?|^([\w.-]+)\.git)$/

--- a/components/Projects/ProjectSettingsDialog.tsx
+++ b/components/Projects/ProjectSettingsDialog.tsx
@@ -34,6 +34,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { devServerKeys } from "@/data/dev-servers";
 import { repositoryKeys } from "@/data/repositories";
 import type { AgentType } from "@/lib/providers";
+import {
+  getDefaultModelForAgent,
+  getModelOptions,
+  isSupportedModelForAgent,
+} from "@/lib/model-catalog";
 import type {
   ProjectWithRepositories,
   DetectedDevServer,
@@ -49,12 +54,6 @@ const AGENT_OPTIONS: { value: AgentType; label: string }[] = [
   { value: "amp", label: "Amp" },
   { value: "pi", label: "Pi" },
   { value: "omp", label: "Oh My Pi" },
-];
-
-const MODEL_OPTIONS = [
-  { value: "sonnet", label: "Sonnet" },
-  { value: "opus", label: "Opus" },
-  { value: "haiku", label: "Haiku" },
 ];
 
 interface DevServerConfig {
@@ -93,7 +92,9 @@ export function ProjectSettingsDialog({
   const [name, setName] = useState("");
   const [workingDirectory, setWorkingDirectory] = useState("");
   const [agentType, setAgentType] = useState<AgentType>("claude");
-  const [defaultModel, setDefaultModel] = useState("sonnet");
+  const [defaultModel, setDefaultModel] = useState(
+    getDefaultModelForAgent("claude")
+  );
   const [initialPrompt, setInitialPrompt] = useState("");
   const [devServers, setDevServers] = useState<DevServerConfig[]>([]);
   const [repositories, setRepositories] = useState<RepositoryConfig[]>([]);
@@ -107,6 +108,10 @@ export function ProjectSettingsDialog({
 
   const updateProject = useUpdateProject();
   const queryClient = useQueryClient();
+  const modelOptions = getModelOptions(agentType);
+  const selectedModelLabel =
+    modelOptions.find((option) => option.value === defaultModel)?.label ||
+    "Select a model";
 
   // Initialize form when project changes
   useEffect(() => {
@@ -114,7 +119,11 @@ export function ProjectSettingsDialog({
       setName(project.name);
       setWorkingDirectory(project.working_directory);
       setAgentType(project.agent_type);
-      setDefaultModel(project.default_model);
+      setDefaultModel(
+        isSupportedModelForAgent(project.agent_type, project.default_model)
+          ? project.default_model
+          : getDefaultModelForAgent(project.agent_type)
+      );
       setInitialPrompt(project.initial_prompt || "");
       setDevServers(
         project.devServers.map((ds) => ({
@@ -434,6 +443,15 @@ export function ProjectSettingsDialog({
   const visibleDevServers = devServers.filter((ds) => !ds.isDeleted);
   const visibleRepositories = repositories.filter((repo) => !repo.isDeleted);
 
+  const handleAgentTypeChange = (value: AgentType) => {
+    setAgentType(value);
+    setDefaultModel((current) =>
+      isSupportedModelForAgent(value, current)
+        ? current
+        : getDefaultModelForAgent(value)
+    );
+  };
+
   if (!project) return null;
 
   return (
@@ -473,7 +491,7 @@ export function ProjectSettingsDialog({
               <label className="text-sm font-medium">Default Agent</label>
               <Select
                 value={agentType}
-                onValueChange={(v) => setAgentType(v as AgentType)}
+                onValueChange={(v) => handleAgentTypeChange(v as AgentType)}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -491,12 +509,16 @@ export function ProjectSettingsDialog({
             {/* Default Model */}
             <div className="space-y-2">
               <label className="text-sm font-medium">Default Model</label>
-              <Select value={defaultModel} onValueChange={setDefaultModel}>
+              <Select
+                key={agentType}
+                value={defaultModel}
+                onValueChange={setDefaultModel}
+              >
                 <SelectTrigger>
-                  <SelectValue />
+                  <SelectValue>{selectedModelLabel}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  {MODEL_OPTIONS.map((opt) => (
+                  {modelOptions.map((opt) => (
                     <SelectItem key={opt.value} value={opt.value}>
                       {opt.label}
                     </SelectItem>

--- a/components/Projects/hooks/useNewProjectForm.ts
+++ b/components/Projects/hooks/useNewProjectForm.ts
@@ -1,5 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import type { AgentType } from "@/lib/providers";
+import {
+  getDefaultModelForAgent,
+  isSupportedModelForAgent,
+} from "@/lib/model-catalog";
 import { useCreateProject, useDetectDevServers } from "@/data/projects";
 import { useGitCheck, useCloneRepo } from "@/data/git/queries";
 import {
@@ -20,7 +24,9 @@ export function useNewProjectForm(
   const [workingDirectory, setWorkingDirectory] = useState("~");
   const [debouncedDir, setDebouncedDir] = useState("~");
   const [agentType, setAgentType] = useState<AgentType>("claude");
-  const [defaultModel, setDefaultModel] = useState("opus");
+  const [defaultModel, setDefaultModel] = useState(
+    getDefaultModelForAgent("claude")
+  );
   const [devServers, setDevServers] = useState<DevServerConfig[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [recentDirs, setRecentDirs] = useState<string[]>([]);
@@ -105,13 +111,22 @@ export function useNewProjectForm(
     setName("");
     setWorkingDirectory("~");
     setAgentType("claude");
-    setDefaultModel("opus");
+    setDefaultModel(getDefaultModelForAgent("claude"));
     setDevServers([]);
     setGithubUrl("");
     setCloneStep(CLONE_STEP.IDLE);
     setError(null);
     onClose();
   };
+
+  const handleAgentTypeChange = useCallback((value: AgentType) => {
+    setAgentType(value);
+    setDefaultModel((current) =>
+      isSupportedModelForAgent(value, current)
+        ? current
+        : getDefaultModelForAgent(value)
+    );
+  }, []);
 
   const handleGithubUrlChange = (value: string) => {
     setGithubUrl(value);
@@ -222,7 +237,7 @@ export function useNewProjectForm(
     workingDirectory,
     setWorkingDirectory,
     agentType,
-    setAgentType,
+    handleAgentTypeChange,
     defaultModel,
     setDefaultModel,
     devServers,

--- a/data/sessions/queries.ts
+++ b/data/sessions/queries.ts
@@ -178,6 +178,7 @@ export interface CreateSessionInput {
   name?: string;
   workingDirectory: string;
   projectId: string | null;
+  model: string;
   agentType: AgentType;
   useWorktree: boolean;
   featureName: string | null;

--- a/lib/model-catalog.ts
+++ b/lib/model-catalog.ts
@@ -1,0 +1,80 @@
+import type { AgentType } from "./providers";
+
+export interface ModelOption {
+  value: string;
+  label: string;
+}
+
+const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
+  { value: "sonnet", label: "Sonnet" },
+  { value: "opus", label: "Opus" },
+  { value: "haiku", label: "Haiku" },
+];
+
+const CODEX_MODEL_OPTIONS: ModelOption[] = [
+  { value: "gpt-5.4", label: "GPT-5.4" },
+  { value: "gpt-5.4-mini", label: "GPT-5.4 mini" },
+  { value: "gpt-5.4-nano", label: "GPT-5.4 nano" },
+  { value: "gpt-5.2-codex", label: "GPT-5.2-Codex" },
+];
+
+const GEMINI_MODEL_OPTIONS: ModelOption[] = [
+  { value: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+  { value: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
+  {
+    value: "gemini-3.1-flash-lite-preview",
+    label: "Gemini 3.1 Flash-Lite Preview",
+  },
+  { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+  { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  { value: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash-Lite" },
+];
+
+const MODEL_OPTIONS_BY_AGENT: Partial<Record<AgentType, ModelOption[]>> = {
+  claude: CLAUDE_MODEL_OPTIONS,
+  codex: CODEX_MODEL_OPTIONS,
+  gemini: GEMINI_MODEL_OPTIONS,
+};
+
+const DEFAULT_MODEL_BY_AGENT: Partial<Record<AgentType, string>> = {
+  claude: "sonnet",
+  codex: "gpt-5.4",
+  gemini: "gemini-2.5-pro",
+};
+
+export function getModelOptions(agentType: AgentType): ModelOption[] {
+  return MODEL_OPTIONS_BY_AGENT[agentType] ?? CLAUDE_MODEL_OPTIONS;
+}
+
+export function getDefaultModelForAgent(agentType: AgentType): string {
+  return (
+    DEFAULT_MODEL_BY_AGENT[agentType] ??
+    getModelOptions(agentType)[0]?.value ??
+    "sonnet"
+  );
+}
+
+export function isSupportedModelForAgent(
+  agentType: AgentType,
+  model: string | null | undefined
+): boolean {
+  if (!model) {
+    return false;
+  }
+
+  return getModelOptions(agentType).some((option) => option.value === model);
+}
+
+export function resolveModelForAgent(
+  agentType: AgentType,
+  model: string | null | undefined
+): string {
+  const normalizedModel =
+    typeof model === "string" && model.trim() ? model.trim() : null;
+
+  if (normalizedModel && isSupportedModelForAgent(agentType, normalizedModel)) {
+    return normalizedModel;
+  }
+
+  return getDefaultModelForAgent(agentType);
+}

--- a/lib/orchestration.ts
+++ b/lib/orchestration.ts
@@ -11,6 +11,7 @@ import { promisify } from "util";
 import { db, queries, type Session } from "./db";
 import { createWorktree, deleteWorktree } from "./worktrees";
 import { setupWorktree } from "./env-setup";
+import { resolveModelForAgent } from "./model-catalog";
 import { type AgentType, getProvider } from "./providers";
 import { statusDetector } from "./status-detector";
 import { wrapWithBanner } from "./banner";
@@ -85,9 +86,9 @@ export async function spawnWorker(
     workingDirectory: rawWorkingDir,
     branchName = taskToBranchName(task),
     useWorktree = true,
-    model = "sonnet",
     agentType = "claude",
   } = options;
+  const model = resolveModelForAgent(agentType, options.model);
 
   // Expand ~ to home directory
   const workingDirectory = rawWorkingDir.replace(/^~/, process.env.HOME || "");

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -19,6 +19,7 @@ import {
   type Session,
   type DevServerType,
 } from "./db";
+import { resolveModelForAgent } from "./model-catalog";
 import type { AgentType } from "./providers";
 
 const execAsync = promisify(exec);
@@ -96,7 +97,7 @@ export function createProject(
       opts.name,
       opts.workingDirectory,
       opts.agentType || "claude",
-      opts.defaultModel || "sonnet",
+      resolveModelForAgent(opts.agentType || "claude", opts.defaultModel),
       opts.initialPrompt || null,
       maxOrder + 1
     );
@@ -239,14 +240,18 @@ export function updateProject(
 ): Project | undefined {
   const project = getProject(id);
   if (!project || project.is_uncategorized) return undefined;
+  const agentType = updates.agent_type ?? project.agent_type;
 
   queries
     .updateProject(db)
     .run(
       updates.name ?? project.name,
       updates.working_directory ?? project.working_directory,
-      updates.agent_type ?? project.agent_type,
-      updates.default_model ?? project.default_model,
+      agentType,
+      resolveModelForAgent(
+        agentType,
+        updates.default_model ?? project.default_model
+      ),
       updates.initial_prompt !== undefined
         ? updates.initial_prompt
         : project.initial_prompt,


### PR DESCRIPTION
## Summary
- add a shared provider model catalog for Claude, Codex, and Gemini
- update project dialogs to show provider-specific model options and reset invalid selections when the agent changes
- resolve session and worker defaults from the selected provider instead of hardcoding `sonnet`

## Testing
- `npm run typecheck` via pre-commit hook
