### PR TITLE
Add Kilo Code CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm run dev  # http://localhost:3011
 - Node.js 20+
 - tmux
 - [ripgrep](https://github.com/BurntSushi/ripgrep) (for code search - auto-installed by installer script, or run `agent-os update`)
-- At least one AI CLI: [Claude Code](https://github.com/anthropics/claude-code), [Codex](https://github.com/openai/codex), [OpenCode](https://github.com/anomalyco/opencode), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Aider](https://aider.chat/), or [Cursor CLI](https://cursor.com/cli)
+- At least one AI CLI: [Claude Code](https://github.com/anthropics/claude-code), [Codex](https://github.com/openai/codex), [OpenCode](https://github.com/anomalyco/opencode), [Kilo Code CLI](https://kilo.ai/docs/cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Aider](https://aider.chat/), or [Cursor CLI](https://cursor.com/cli)
 
 ## Supported Agents
 
@@ -68,6 +68,7 @@ npm run dev  # http://localhost:3011
 | Claude Code | ✅     | ✅   | `--dangerously-skip-permissions` |
 | Codex       | ❌     | ❌   | `--approval-mode full-auto`      |
 | OpenCode    | ❌     | ❌   | Config file                      |
+| Kilo Code   | ✅     | ✅   | Config file                      |
 | Gemini CLI  | ❌     | ❌   | `--yolomode`                     |
 | Aider       | ❌     | ❌   | `--yes`                          |
 | Cursor CLI  | ❌     | ❌   | N/A                              |

--- a/app/api/tmux/kill-all/route.ts
+++ b/app/api/tmux/kill-all/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { getDb, queries, type Session } from "@/lib/db";
+import { getManagedSessionPattern } from "@/lib/providers/registry";
 
 const execAsync = promisify(exec);
 
@@ -16,12 +17,11 @@ export async function POST() {
       { timeout: 5000 }
     );
 
+    const managedSessionPattern = getManagedSessionPattern();
     const tmuxSessions = stdout
       .trim()
       .split("\n")
-      .filter(
-        (s) => s && /^(claude|codex|opencode|gemini|aider|cursor)-/.test(s)
-      );
+      .filter((s) => s && managedSessionPattern.test(s));
 
     // Kill each tmux session
     const killed: string[] = [];

--- a/components/NewSessionDialog/NewSessionDialog.types.ts
+++ b/components/NewSessionDialog/NewSessionDialog.types.ts
@@ -93,6 +93,7 @@ export const AGENT_OPTIONS: {
   { value: "claude", label: "Claude Code", description: "Anthropic's CLI" },
   { value: "codex", label: "Codex", description: "OpenAI's CLI" },
   { value: "opencode", label: "OpenCode", description: "Multi-provider CLI" },
+  { value: "kilocode", label: "Kilo Code", description: "Kilo's AI coding CLI" },
   { value: "gemini", label: "Gemini CLI", description: "Google's CLI" },
   { value: "aider", label: "Aider", description: "AI pair programming" },
   { value: "cursor", label: "Cursor CLI", description: "Cursor's AI agent" },

--- a/components/Projects/NewProjectDialog.types.ts
+++ b/components/Projects/NewProjectDialog.types.ts
@@ -32,6 +32,7 @@ export const AGENT_OPTIONS: { value: AgentType; label: string }[] = [
   { value: "claude", label: "Claude Code" },
   { value: "codex", label: "Codex" },
   { value: "opencode", label: "OpenCode" },
+  { value: "kilocode", label: "Kilo Code" },
   { value: "gemini", label: "Gemini CLI" },
   { value: "aider", label: "Aider" },
   { value: "cursor", label: "Cursor CLI" },

--- a/components/Projects/ProjectSettingsDialog.tsx
+++ b/components/Projects/ProjectSettingsDialog.tsx
@@ -48,6 +48,7 @@ const AGENT_OPTIONS: { value: AgentType; label: string }[] = [
   { value: "claude", label: "Claude Code" },
   { value: "codex", label: "Codex" },
   { value: "opencode", label: "OpenCode" },
+  { value: "kilocode", label: "Kilo Code" },
   { value: "gemini", label: "Gemini CLI" },
   { value: "aider", label: "Aider" },
   { value: "cursor", label: "Cursor CLI" },

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -72,6 +72,7 @@ You need at least one AI coding CLI installed. The installer will prompt you to 
 | Codex       | OpenAI    | `npm install -g @openai/codex`             |
 | Aider       | Multi-LLM | `pip install aider-chat`                   |
 | Gemini CLI  | Google    | `npm install -g gemini-cli`                |
+| Kilo Code CLI | Kilo   | `npm install -g @kilocode/cli`             |
 
 ## Configuration
 

--- a/lib/providers.ts
+++ b/lib/providers.ts
@@ -241,6 +241,62 @@ export const opencodeProvider: AgentProvider = {
 };
 
 /**
+ * Kilo Code Provider
+ * Kilo's AI coding CLI
+ */
+export const kilocodeProvider: AgentProvider = {
+  id: "kilocode",
+  name: "Kilo Code",
+  description: "Kilo's AI coding CLI",
+  command: "kilo",
+  configDir: "~/.config/kilo/kilo.json",
+
+  supportsResume: true,
+  supportsFork: true,
+
+  buildFlags(options: BuildFlagsOptions): string[] {
+    const def = getProviderDefinition("kilocode");
+    const flags: string[] = [];
+
+    // AgentOS launches the interactive TUI; approval-bypass flags are only
+    // documented for `kilo run`, so interactive approvals are managed via config.
+    if (options.skipPermissions) {
+      // No documented skip-permissions flag for interactive mode.
+    }
+
+    if (options.sessionId && def.resumeFlag) {
+      flags.push(def.resumeFlag);
+      flags.push(options.sessionId);
+    } else if (options.parentSessionId && def.resumeFlag) {
+      flags.push(def.resumeFlag);
+      flags.push(options.parentSessionId);
+      flags.push("--fork");
+    }
+
+    if (options.initialPrompt?.trim() && def.initialPromptFlag) {
+      const prompt = options.initialPrompt.trim();
+      const escapedPrompt = prompt.replace(/'/g, "'\\''");
+      flags.push(def.initialPromptFlag);
+      flags.push(`'${escapedPrompt}'`);
+    }
+
+    return flags;
+  },
+
+  waitingPatterns: [
+    /\[Y\/n\]/i,
+    /\[y\/N\]/i,
+    /confirm/i,
+    /Press Enter/i,
+    /\(yes\/no\)/i,
+  ],
+
+  runningPatterns: [/thinking/i, /processing/i, /working/i, SPINNER_CHARS],
+
+  idlePatterns: [/^>\s*$/m, /kilo(?:code)?.*>\s*$/im, /\$\s*$/m],
+};
+
+/**
  * Gemini CLI Provider
  * Google's AI coding CLI powered by Gemini models
  */
@@ -576,6 +632,7 @@ export const providers: Record<AgentType, AgentProvider> = {
   claude: claudeProvider,
   codex: codexProvider,
   opencode: opencodeProvider,
+  kilocode: kilocodeProvider,
   gemini: geminiProvider,
   aider: aiderProvider,
   cursor: cursorProvider,

--- a/lib/providers/registry.ts
+++ b/lib/providers/registry.ts
@@ -8,6 +8,7 @@ export const PROVIDER_IDS = [
   "claude",
   "codex",
   "opencode",
+  "kilocode",
   "gemini",
   "aider",
   "cursor",
@@ -90,6 +91,18 @@ export const PROVIDERS: ProviderDefinition[] = [
     autoApproveFlag: undefined, // OpenCode manages this via config
     supportsResume: false,
     supportsFork: false,
+    initialPromptFlag: "--prompt",
+  },
+  {
+    id: "kilocode",
+    name: "Kilo Code",
+    description: "Kilo's AI coding CLI",
+    cli: "kilo",
+    configDir: "~/.config/kilo/kilo.json",
+    autoApproveFlag: undefined, // Kilo manages this via config
+    supportsResume: true,
+    supportsFork: true,
+    resumeFlag: "--session",
     initialPromptFlag: "--prompt",
   },
   {

--- a/scripts/lib/ai-clis.sh
+++ b/scripts/lib/ai-clis.sh
@@ -7,6 +7,7 @@ detect_ai_clis() {
     command -v claude &> /dev/null && installed+=("claude")
     command -v codex &> /dev/null && installed+=("codex")
     command -v opencode &> /dev/null && installed+=("opencode")
+    command -v kilo &> /dev/null && installed+=("kilo")
     command -v gemini &> /dev/null && installed+=("gemini")
     command -v aider &> /dev/null && installed+=("aider")
     command -v cursor &> /dev/null && installed+=("cursor")
@@ -82,6 +83,20 @@ install_gemini_cli() {
     gemini auth login 2>/dev/null || true
 }
 
+install_kilocode_cli() {
+    if command -v kilo &> /dev/null; then
+        log_success "Kilo Code CLI already installed"
+        return 0
+    fi
+
+    log_info "Installing Kilo Code CLI..."
+    npm install -g @kilocode/cli
+
+    log_info "Authenticating Kilo Code CLI..."
+    echo ""
+    echo "Run 'kilo' to complete setup and authentication when ready."
+}
+
 prompt_ai_cli_install() {
     local installed
     installed=$(detect_ai_clis)
@@ -100,7 +115,8 @@ prompt_ai_cli_install() {
     echo "  2) Codex (OpenAI)"
     echo "  3) Aider (Multi-LLM)"
     echo "  4) Gemini CLI (Google)"
-    echo "  5) Skip - I'll install one myself"
+    echo "  5) Kilo Code CLI (Kilo)"
+    echo "  6) Skip - I'll install one myself"
     echo ""
 
     if ! is_interactive; then
@@ -109,7 +125,7 @@ prompt_ai_cli_install() {
         return
     fi
 
-    read -p "Which would you like to install? [1-5, default: 1] " -r choice
+    read -p "Which would you like to install? [1-6, default: 1] " -r choice
     echo ""
 
     case "${choice:-1}" in
@@ -117,7 +133,8 @@ prompt_ai_cli_install() {
         2) install_codex ;;
         3) install_aider ;;
         4) install_gemini_cli ;;
-        5)
+        5) install_kilocode_cli ;;
+        6)
             log_info "Skipping AI CLI installation"
             echo ""
             echo "Install one of these before using AgentOS:"
@@ -125,6 +142,7 @@ prompt_ai_cli_install() {
             echo "  Codex:       npm install -g @openai/codex"
             echo "  Aider:       pip install aider-chat"
             echo "  Gemini:      npm install -g gemini-cli"
+            echo "  Kilo Code:   npm install -g @kilocode/cli"
             echo ""
             ;;
         *) log_warn "Invalid choice, skipping" ;;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -27,13 +27,20 @@ if ! command -v tmux &> /dev/null; then
 fi
 echo "tmux: $(tmux -V)"
 
-# Check Claude CLI
-if ! command -v claude &> /dev/null; then
-    echo "Error: Claude Code CLI is not installed"
-    echo "Install: npm install -g @anthropic-ai/claude-code"
+# Check AI coding CLI
+AI_CLI_FOUND=""
+for cli in claude codex opencode kilo gemini aider cursor-agent amp pi omp; do
+    if command -v "$cli" &> /dev/null; then
+        AI_CLI_FOUND="$AI_CLI_FOUND $cli"
+    fi
+done
+
+if [ -z "$AI_CLI_FOUND" ]; then
+    echo "Error: no supported AI coding CLI is installed"
+    echo "Install one of: Claude Code, Codex, OpenCode, Kilo Code CLI, Gemini CLI, Aider, Cursor CLI, Amp, Pi, or Oh My Pi"
     exit 1
 fi
-echo "Claude CLI: installed"
+echo "AI CLI(s):$AI_CLI_FOUND"
 
 # Check jq
 if ! command -v jq &> /dev/null; then


### PR DESCRIPTION
## Summary

Adds Kilo Code CLI as a supported AgentOS provider, using the `kilo` executable and `~/.config/kilo/kilo.json` config path.

## Changes

- Adds a `kilocode` provider definition and runtime provider implementation.
- Supports Kilo resume/fork flags with `--session <id>` and `--fork`.
- Exposes Kilo Code in new-session, new-project, and project-settings agent selectors.
- Routes AgentOS tmux cleanup through the centralized managed-session provider pattern.
- Detects and installs the Kilo CLI through setup helper scripts.
- Updates README and setup docs to list Kilo Code CLI.
- Updates local setup validation so it accepts any supported AI CLI instead of requiring Claude only.

## Validation

- `npm run typecheck`
- `bash -n scripts/setup.sh scripts/lib/ai-clis.sh`
- `git diff --check`
